### PR TITLE
Add backend-safe link generation to prevent session corruption

### DIFF
--- a/Classes/Typo3/Utility/BackendSafeUriBuilder.php
+++ b/Classes/Typo3/Utility/BackendSafeUriBuilder.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace BR\Toolkit\Typo3\Utility;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+
+/**
+ * Backend-safe UriBuilder that uses native TYPO3 Site routing
+ *
+ * This builder can be used as a drop-in replacement for the standard UriBuilder
+ * in backend context, preventing session corruption issues.
+ */
+class BackendSafeUriBuilder extends UriBuilder
+{
+    /**
+     * @var int|null
+     */
+    protected $targetPageUid;
+
+    /**
+     * @var array
+     */
+    protected $arguments = [];
+
+    /**
+     * @var bool
+     */
+    protected $createAbsoluteUri = false;
+
+    /**
+     * @var int
+     */
+    protected $targetPageType = 0;
+
+    /**
+     * @var int
+     */
+    protected $languageId = 0;
+
+    /**
+     * @var Site|null
+     */
+    protected $site;
+
+    /**
+     * @var SiteLanguage|null
+     */
+    protected $siteLanguage;
+
+    /**
+     * @param Site|null $site
+     * @param SiteLanguage|null $siteLanguage
+     */
+    public function __construct(?Site $site = null, ?SiteLanguage $siteLanguage = null)
+    {
+        $this->site = $site;
+        $this->siteLanguage = $siteLanguage;
+        if ($siteLanguage) {
+            $this->languageId = $siteLanguage->getLanguageId();
+        }
+    }
+
+    /**
+     * @param int $targetPageUid
+     * @return $this
+     */
+    public function setTargetPageUid($targetPageUid): self
+    {
+        $this->targetPageUid = (int)$targetPageUid;
+        return $this;
+    }
+
+    /**
+     * @param int $targetPageType
+     * @return $this
+     */
+    public function setTargetPageType($targetPageType): self
+    {
+        $this->targetPageType = (int)$targetPageType;
+        return $this;
+    }
+
+    /**
+     * @param array $arguments
+     * @return $this
+     */
+    public function setArguments(array $arguments): self
+    {
+        $this->arguments = $arguments;
+        return $this;
+    }
+
+    /**
+     * @param bool $createAbsoluteUri
+     * @return $this
+     */
+    public function setCreateAbsoluteUri($createAbsoluteUri): self
+    {
+        $this->createAbsoluteUri = (bool)$createAbsoluteUri;
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function reset(): self
+    {
+        $this->targetPageUid = null;
+        $this->arguments = [];
+        $this->createAbsoluteUri = false;
+        $this->targetPageType = 0;
+        return $this;
+    }
+
+    /**
+     * Build the URI using backend-safe Site routing
+     *
+     * @return string
+     */
+    public function build(): string
+    {
+        if ($this->targetPageUid === null) {
+            return '';
+        }
+
+        // Add page type to arguments if set
+        $arguments = $this->arguments;
+        if ($this->targetPageType > 0) {
+            $arguments['type'] = $this->targetPageType;
+        }
+
+        return FrontendUtility::generateBackendSafeLink(
+            $this->targetPageUid,
+            $arguments,
+            $this->languageId
+        );
+    }
+
+    /**
+     * Builds the URI but doesn't apply TYPO3 cHash
+     * In our case, this is the same as build() since Site routing handles cHash
+     *
+     * @return string
+     */
+    public function buildFrontendUri(): string
+    {
+        return $this->build();
+    }
+}

--- a/Classes/Typo3/Utility/FrontendUtility.php
+++ b/Classes/Typo3/Utility/FrontendUtility.php
@@ -191,6 +191,63 @@ abstract class FrontendUtility
     }
 
     /**
+     * Generate frontend link safe for backend context
+     * Uses native TYPO3 Site routing without session manipulation
+     *
+     * This method is safe to use in backend context (DataHandler hooks, backend modules, etc.)
+     * because it uses TYPO3's Site router directly without initializing TSFE or frontend sessions.
+     *
+     * @param int $pageUid
+     * @param array $additionalParams
+     * @param int $languageId
+     * @return string
+     */
+    public static function generateBackendSafeLink(int $pageUid, array $additionalParams = [], int $languageId = 0): string
+    {
+        try {
+            $site = static::getSite($pageUid);
+            $language = $languageId > 0 ? $site->getLanguageById($languageId) : $site->getDefaultLanguage();
+
+            // Use Site router directly - NO TSFE initialization, NO session manipulation
+            $uri = $site->getRouter()->generateUri(
+                $pageUid,
+                $additionalParams,
+                '',
+                $language->getTypo3Language()
+            );
+
+            return (string)$uri;
+        } catch (\Exception $e) {
+            return '';
+        }
+    }
+
+    /**
+     * Check if we are in backend context
+     *
+     * @return bool
+     */
+    protected static function isBackendContext(): bool
+    {
+        // Check for TYPO3_MODE constant (TYPO3 v10)
+        if (defined('TYPO3_MODE') && TYPO3_MODE === 'BE') {
+            return true;
+        }
+
+        // Check request attribute for application type (TYPO3 v10+)
+        if (isset($GLOBALS['TYPO3_REQUEST']) &&
+            $GLOBALS['TYPO3_REQUEST'] instanceof \Psr\Http\Message\ServerRequestInterface) {
+            $applicationType = $GLOBALS['TYPO3_REQUEST']->getAttribute('applicationType');
+            if ($applicationType === \TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE) {
+                return true;
+            }
+        }
+
+        // Check for BE_USER as fallback
+        return isset($GLOBALS['BE_USER']) && $GLOBALS['BE_USER'] instanceof \TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+    }
+
+    /**
      * @param Site|null $site
      * @param SiteLanguage|null $siteLanguage
      * @param int $type
@@ -201,6 +258,18 @@ abstract class FrontendUtility
      */
     public static function getUriBuilder(?Site $site = null, ?SiteLanguage $siteLanguage = null, int $type = 0): UriBuilder
     {
+        // Check if we are in backend context
+        if (self::isBackendContext()) {
+            // In backend: return backend-safe UriBuilder to avoid session corruption
+            if ($site === null) {
+                $site = static::getSite();
+            }
+            if ($siteLanguage === null) {
+                $siteLanguage = $site->getDefaultLanguage();
+            }
+            return new BackendSafeUriBuilder($site, $siteLanguage);
+        }
+
         if (static::$uriBuilder === null) {
             static::getFrontendController($site, $siteLanguage, $type);
             /** @var UriBuilder $uriBuilder */


### PR DESCRIPTION
## Problem
  In TYPO3 10.4.55+, generating frontend links from backend context (e.g., DataHandler hooks) causes session corruption due to `FrontendUserAuthentication::start()` overwriting the backend user session. This results in automatic logout for non-admin backend users.

  ## Solution
  This PR adds backend-safe link generation that uses native TYPO3 Site routing without TSFE initialization:

  - **New method**: `FrontendUtility::generateBackendSafeLink()` - Direct link generation using Site router
  - **New class**: `BackendSafeUriBuilder` - Drop-in replacement for UriBuilder in backend context
  - **Auto-detection**: `getUriBuilder()` automatically returns `BackendSafeUriBuilder` when called from backend

  ## Benefits
  - ✅ No session corruption in backend context
  - ✅ Transparent - existing code works without changes
  - ✅ Backward compatible - frontend behavior unchanged
  - ✅ Two usage options: automatic (via `getUriBuilder()`) or direct (via `generateBackendSafeLink()`)

  ## Testing
  Tested in TYPO3 10.4.55 ELTS with DataHandler hooks - no more logout issues for non-admin users.
